### PR TITLE
add channel version and common interface

### DIFF
--- a/cb/cb.go
+++ b/cb/cb.go
@@ -6,6 +6,17 @@ package cb
 
 import "sync"
 
+type Queue[T any] interface {
+	Empty() bool
+	Full() bool
+	Size() int
+	Capacity() int
+	Push(item T) bool
+	Pop() (value T, ok bool)
+	PushBlocking(item T)
+	PopBlocking() (value T)
+}
+
 type CircularBuffer[T any] struct {
 	buffer []T
 	head   int
@@ -16,7 +27,7 @@ type CircularBuffer[T any] struct {
 	empty  *sync.Cond
 }
 
-func New[T any](capacity int) *CircularBuffer[T] {
+func New[T any](capacity int) Queue[T] {
 	cb := &CircularBuffer[T]{
 		buffer: make([]T, capacity),
 		head:   0,

--- a/cb/cb.go
+++ b/cb/cb.go
@@ -30,7 +30,7 @@ type CircularBuffer[T any] struct {
 	empty  sync.Cond
 }
 
-// NewC returns the fixed array version of 0 alloc fixed capacity (optionally blocking) [Queue].
+// New returns the fixed array version of 0 alloc fixed capacity (optionally blocking) [Queue].
 func New[T any](capacity int) *CircularBuffer[T] {
 	cb := &CircularBuffer[T]{
 		buffer: make([]T, capacity),

--- a/cb/cb.go
+++ b/cb/cb.go
@@ -26,8 +26,8 @@ type CircularBuffer[T any] struct {
 	tail   int
 	size   int
 	mu     sync.Mutex
-	full   *sync.Cond
-	empty  *sync.Cond
+	full   sync.Cond
+	empty  sync.Cond
 }
 
 // NewC returns the fixed array version of 0 alloc fixed capacity (optionally blocking) [Queue].
@@ -38,8 +38,8 @@ func New[T any](capacity int) *CircularBuffer[T] {
 		tail:   0,
 		size:   0,
 	}
-	cb.full = sync.NewCond(&cb.mu)
-	cb.empty = sync.NewCond(&cb.mu)
+	cb.full.L = &cb.mu
+	cb.empty.L = &cb.mu
 	return cb
 }
 

--- a/cb/cb.go
+++ b/cb/cb.go
@@ -1,7 +1,9 @@
-// FIFO Queue with fixed capacity.
+// First In First Out (FIFO) [Queue] with fixed capacity.
 // Circular Buffer implementation in Go with both
 // pub/sub thread safe blocking API and pure FIFO queue with set capacity
-// unsynchronized base.
+// unsynchronized base. Two versions of the same [Queue] interface:
+// one actually a circular buffer [CircularBuffer], the other using a channel
+// [CircularBufferChan], created using [cb.New] or [cb.NewC] respectively.
 package cb
 
 import "sync"
@@ -17,6 +19,7 @@ type Queue[T any] interface {
 	PopBlocking() (value T)
 }
 
+// FIFO [Queue] with fixed capacity. Fixed array implementation.
 type CircularBuffer[T any] struct {
 	buffer []T
 	head   int
@@ -27,7 +30,8 @@ type CircularBuffer[T any] struct {
 	empty  *sync.Cond
 }
 
-func New[T any](capacity int) Queue[T] {
+// NewC returns the fixed array version of 0 alloc fixed capacity (optionally blocking) [Queue].
+func New[T any](capacity int) *CircularBuffer[T] {
 	cb := &CircularBuffer[T]{
 		buffer: make([]T, capacity),
 		head:   0,

--- a/cb/cb_channel.go
+++ b/cb/cb_channel.go
@@ -1,15 +1,14 @@
-// FIFO Queue with fixed capacity.
-// Circular Buffer implementation in Go with both
-// pub/sub thread safe blocking API and pure FIFO queue with set capacity
-// unsynchronized base.
-// Channel / go idiomatic version.
 package cb
 
+// FIFO [Queue] with fixed capacity.
+// Channel / go idiomatic version (blocking, multi thread safe),
+// use [CircularBufferChan] for low/no contention cases as it is faster.
 type CircularBufferChan[T any] struct {
 	buffer chan T
 }
 
-func NewC[T any](capacity int) Queue[T] {
+// NewC returns a channel ([CircularBufferChan]) version of 0 alloc pub/sub fixed capacity blocking queue.
+func NewC[T any](capacity int) *CircularBufferChan[T] {
 	cb := &CircularBufferChan[T]{
 		buffer: make(chan T, capacity),
 	}

--- a/cb/cb_channel.go
+++ b/cb/cb_channel.go
@@ -1,0 +1,71 @@
+// FIFO Queue with fixed capacity.
+// Circular Buffer implementation in Go with both
+// pub/sub thread safe blocking API and pure FIFO queue with set capacity
+// unsynchronized base.
+// Channel / go idiomatic version.
+package cb
+
+type CircularBufferChan[T any] struct {
+	buffer chan T
+}
+
+func NewC[T any](capacity int) Queue[T] {
+	cb := &CircularBufferChan[T]{
+		buffer: make(chan T, capacity),
+	}
+	return cb
+}
+
+func (cb *CircularBufferChan[T]) Empty() bool {
+	return len(cb.buffer) == 0
+}
+
+func (cb *CircularBufferChan[T]) Full() bool {
+	return len(cb.buffer) == cap(cb.buffer)
+}
+
+func (cb *CircularBufferChan[T]) Size() int {
+	return len(cb.buffer)
+}
+
+func (cb *CircularBufferChan[T]) Capacity() int {
+	return cap(cb.buffer)
+}
+
+// Push adds an item to the queue. returns false if queue is full.
+// Note: might block and not return false at times. Use PushBlocking for
+// correct version.
+func (cb *CircularBufferChan[T]) Push(item T) bool {
+	// Note: this is for equivalent with the array/conditional variable version
+	// but isn't correct, as in Full can return false and yet the push can block
+	// if another producer enqueued in the meanwhile.
+	if cb.Full() {
+		return false
+	}
+	cb.buffer <- item
+	return true
+}
+
+// Pop removes an item from the queue. returns false if queue is empty.
+// Note: might block and not return false at times. Use PopBlocking for
+// correct version.
+func (cb *CircularBufferChan[T]) Pop() (value T, ok bool) {
+	if cb.Empty() {
+		return
+	}
+	ok = true
+	value = <-cb.buffer
+	return
+}
+
+// Thread safe blocking versions:
+
+// Push adds an item to the queue. blocks if queue is full.
+func (cb *CircularBufferChan[T]) PushBlocking(item T) {
+	cb.buffer <- item
+}
+
+// Pop removes an item from the queue. blocks if queue is empty.
+func (cb *CircularBufferChan[T]) PopBlocking() T {
+	return <-cb.buffer
+}


### PR DESCRIPTION
refactor tests/benchmark to run both implementations

```
BenchmarkCircularBuffer/CircBuffer-8         	291011238	         4.111 ns/op	       0 B/op	       0 allocs/op
BenchmarkCircularBuffer/Channel-8            	40486740	        30.50 ns/op	       0 B/op	       0 allocs/op

BenchmarkCircularBufferBlocking/CircBuffer-8 	47137462	        25.37 ns/op	       0 B/op	       0 allocs/op
BenchmarkCircularBufferBlocking/Channel-8    	40191579	        30.10 ns/op	       0 B/op	       0 allocs/op

BenchmarkHighContention/CircBuffer-8         	   33285	     35950 ns/op	       0 B/op	       0 allocs/op
BenchmarkHighContention/Channel-8            	   89361	     12535 ns/op	       0 B/op	       0 allocs/op
```

so obviously in non threaded cases, the circular buffer (slice based) is much better but as soon as one needs thread safe and blocking behavior the channel takes the edge both in simplicity of the code and in high contention performance (by a factor 2.8x in this last test) - note that for low contention (2 threads, 1 Producer 1 Consumer) the slice+2conds version still beats the channel
